### PR TITLE
fix: add proactive SQLite test file permission fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,19 @@ jobs:
         if: runner.os != 'Windows'
         run: scripts/ci/install_agent_clis.sh
 
+      - name: Fix SQLite test file permissions (proactive)
+        if: runner.os != 'Windows'
+        run: |
+          # Download dependencies first to ensure SQLite module is cached
+          go mod download
+          # Fix permissions on SQLite test files in go module cache
+          for sqlite_dir in "$HOME/.ci-tmp-home/go/pkg/mod/modernc.org/sqlite@"*; do
+            if [ -d "$sqlite_dir" ]; then
+              find "$sqlite_dir" -type f -exec chmod 644 {} + 2>/dev/null || true
+              find "$sqlite_dir" -type d -exec chmod 755 {} + 2>/dev/null || true
+            fi
+          done
+
       - name: Test (with coverage on ubuntu)
         if: matrix.os == 'ubuntu-latest'
         run: go test ./... -coverprofile=coverage.out -covermode=atomic

--- a/scripts/ci/agent_cli_smoke.sh
+++ b/scripts/ci/agent_cli_smoke.sh
@@ -16,8 +16,6 @@ export HOME="$tmp_home"
 echo
 echo "Using HOME=$HOME"
 
-go run ./cmd/ackchyually shim install git
-
 echo
 echo "Integrate status (before):"
 go run ./cmd/ackchyually integrate status
@@ -29,6 +27,9 @@ go run ./cmd/ackchyually integrate copilot
 echo
 echo "Integrate status (after):"
 go run ./cmd/ackchyually integrate status
+
+# Install git shim after integration to avoid temp dir issues
+go run ./cmd/ackchyually shim install git
 
 echo
 echo "Verify:"


### PR DESCRIPTION
This PR fixes CI test failures by proactively setting correct permissions on SQLite test files before running tests.

**Background:**
The test suite was failing with permission denied errors when trying to remove SQLite test files from the Go module cache. This happens because the SQLite module includes read-only test files that cause cleanup operations to fail.

**Solution:**
- Add a new CI step that runs after dependency download
- Fix file and directory permissions on SQLite test files before tests run
- Prevents permission-related test failures without changing test logic

**Testing:**
- Tests should now complete successfully without permission errors
- No functional changes to application code
- Should resolve failing CI on dependency update PRs